### PR TITLE
 Change `param_grid` to `param_grid_dict`

### DIFF
--- a/benchmark_utils/base_solver.py
+++ b/benchmark_utils/base_solver.py
@@ -22,6 +22,7 @@ with safe_import_context() as import_ctx:
     )
     from skada._utils import Y_Type, _find_y_type
 
+
 class DASolver(BaseSolver):
     strategy = "run_once"
 
@@ -39,8 +40,11 @@ class DASolver(BaseSolver):
         """Return an estimator compatible with the `sklearn.GridSearchCV`."""
         pass
 
-    def set_objective(self, X, y, sample_domain, unmasked_y_train):
+    def set_objective(
+        self, X, y, sample_domain, dataset_name, unmasked_y_train
+    ):
         self.X, self.y, self.sample_domain = X, y, sample_domain
+        self.dataset_name = dataset_name
         self.unmasked_y_train = unmasked_y_train
 
         self.base_estimator = self.get_estimator()
@@ -62,8 +66,9 @@ class DASolver(BaseSolver):
             )
 
         self.clf = GridSearchCV(
-            self.base_estimator, self.param_grid, refit=False,
-            scoring=self.criterions, cv=self.gs_cv, error_score=0.0
+            self.base_estimator, self.param_grid_dict[self.dataset_name],
+            refit=False, scoring=self.criterions, cv=self.gs_cv,
+            error_score=0.0
         )
 
     def run(self, n_iter):

--- a/datasets/digit.py
+++ b/datasets/digit.py
@@ -106,5 +106,6 @@ class Dataset(BaseDataset):
         return dict(
             X=X,
             y=y,
-            sample_domain=sample_domain
+            sample_domain=sample_domain,
+            dataset_name="digit",
         )

--- a/datasets/mushrooms.py
+++ b/datasets/mushrooms.py
@@ -72,5 +72,6 @@ class Dataset(BaseDataset):
         return dict(
             X=X,
             y=y,
-            sample_domain=sample_domain
+            sample_domain=sample_domain,
+            dataset_name="mushrooms",
         )

--- a/datasets/office31surf.py
+++ b/datasets/office31surf.py
@@ -83,4 +83,5 @@ class Dataset(BaseDataset):
             X=X,
             y=y,
             sample_domain=sample_domain,
+            dataset_name="office31surf",
         )

--- a/datasets/simulated.py
+++ b/datasets/simulated.py
@@ -44,4 +44,5 @@ class Dataset(BaseDataset):
             X=X,
             y=y,
             sample_domain=sample_domain,
+            dataset_name="simulated",
         )

--- a/datasets/twentynewsgroups.py
+++ b/datasets/twentynewsgroups.py
@@ -103,5 +103,6 @@ class Dataset(BaseDataset):
         return dict(
             X=X,
             y=y,
-            sample_domain=sample_domain
+            sample_domain=sample_domain,
+            dataset_name="twentynewsgroups",
         )

--- a/objective.py
+++ b/objective.py
@@ -52,11 +52,12 @@ class Objective(BaseObjective):
         'roc_auc_score': roc_auc_score,
     }
 
-    def set_data(self, X, y, sample_domain):
+    def set_data(self, X, y, sample_domain, dataset_name):
         # The keyword arguments of this function are the keys of the dictionary
         # returned by `Dataset.get_data`. This defines the benchmark's
         # API to pass data. This is customizable for each benchmark.
         self.X, self.y, self.sample_domain = X, y, sample_domain
+        self.dataset_name = dataset_name
 
         # check y is discrete or continuous
         self.is_discrete = _find_y_type(self.y) == Y_Type.DISCRETE
@@ -215,5 +216,6 @@ class Objective(BaseObjective):
         return dict(X=X,
                     y=y,
                     sample_domain=sample_domain,
+                    dataset_name=self.dataset_name,
                     unmasked_y_train=unmasked_y_train
                     )

--- a/solvers/CORAL.py
+++ b/solvers/CORAL.py
@@ -19,8 +19,9 @@ class Solver(DASolver):
     # List of parameters for the solver. The benchmark will consider
     # the cross product for each key in the dictionary.
     # All parameters 'p' defined here are available as 'self.p'.
-    param_grid = {
-        'coraladapter__reg': ["auto", 1e-5, 0.5]
+    param_grid_dict = {'simulated': {
+            'coraladapter__reg': ["auto", 1e-5, 0.5]
+        }
     }
 
     def get_estimator(self):

--- a/solvers/JDOT_XGB.py
+++ b/solvers/JDOT_XGB.py
@@ -19,11 +19,12 @@ class Solver(DASolver):
     # List of parameters for the solver. The benchmark will consider
     # the cross product for each key in the dictionary.
     # All parameters 'p' defined here are available as 'self.p'.
-    param_grid = {
-        'jdotclassifier__alpha': [0.5, 0.7, 0.9],
-        'jdotclassifier__n_iter_max': [100, 200, 300],
-        'jdotclassifier__tol': [1e-5, 1e-6],
-        'jdotclassifier__thr_weights': [1e-6, 1e-7],
+    param_grid_dict = {'simulated': {
+            'jdotclassifier__alpha': [0.5, 0.7, 0.9],
+            'jdotclassifier__n_iter_max': [100, 200, 300],
+            'jdotclassifier__tol': [1e-5, 1e-6],
+            'jdotclassifier__thr_weights': [1e-6, 1e-7],
+        }
     }
 
     def get_estimator(self):

--- a/solvers/KLIEP.py
+++ b/solvers/KLIEP.py
@@ -19,12 +19,13 @@ class Solver(DASolver):
     # List of parameters for the solver. The benchmark will consider
     # the cross product for each key in the dictionary.
     # All parameters 'p' defined here are available as 'self.p'.
-    param_grid = {
-        'kliepreweightadapter__gamma': [0.1, 1, 10],
-        'kliepreweightadapter__cv': [3, 5],
-        'kliepreweightadapter__n_centers': [5, 10, 20],
-        'kliepreweightadapter__tol': [1e-3, 1e-4],
-        'kliepreweightadapter__random_state': [0],
+    param_grid_dict = {'simulated': {
+            'kliepreweightadapter__gamma': [0.1, 1, 10],
+            'kliepreweightadapter__cv': [3, 5],
+            'kliepreweightadapter__n_centers': [5, 10, 20],
+            'kliepreweightadapter__tol': [1e-3, 1e-4],
+            'kliepreweightadapter__random_state': [0],
+        }
     }
 
     def get_estimator(self):

--- a/solvers/KMM.py
+++ b/solvers/KMM.py
@@ -19,12 +19,13 @@ class Solver(DASolver):
     # List of parameters for the solver. The benchmark will consider
     # the cross product for each key in the dictionary.
     # All parameters 'p' defined here are available as 'self.p'.
-    param_grid = {
-        'kmmreweightadapter__gamma': [0.1, 1.0, 10.0],
-        'kmmreweightadapter__B': [1000.0],
-        'kmmreweightadapter__tol': [1e-6],
-        'kmmreweightadapter__max_iter': [100],
-        'kmmreweightadapter__smooth_weights': [False],
+    param_grid_dict = {'simulated': {
+            'kmmreweightadapter__gamma': [0.1, 1.0, 10.0],
+            'kmmreweightadapter__B': [1000.0],
+            'kmmreweightadapter__tol': [1e-6],
+            'kmmreweightadapter__max_iter': [100],
+            'kmmreweightadapter__smooth_weights': [False],
+        }
     }
 
     def get_estimator(self):

--- a/solvers/MMDSConS.py
+++ b/solvers/MMDSConS.py
@@ -19,12 +19,13 @@ class Solver(DASolver):
     # List of parameters for the solver. The benchmark will consider
     # the cross product for each key in the dictionary.
     # All parameters 'p' defined here are available as 'self.p'.
-    param_grid = {
-        'mmdlsconsmappingadapter__gamma': [0.1, 1, 10],
-        'mmdlsconsmappingadapter__reg_k': [1e-10, 1e-8],
-        'mmdlsconsmappingadapter__reg_m': [1e-10, 1e-8],
-        'mmdlsconsmappingadapter__tol': [1e-5],
-        'mmdlsconsmappingadapter__max_iter': [100],
+    param_grid_dict = {'simulated': {
+            'mmdlsconsmappingadapter__gamma': [0.1, 1, 10],
+            'mmdlsconsmappingadapter__reg_k': [1e-10, 1e-8],
+            'mmdlsconsmappingadapter__reg_m': [1e-10, 1e-8],
+            'mmdlsconsmappingadapter__tol': [1e-5],
+            'mmdlsconsmappingadapter__max_iter': [100],
+        }
     }
 
     def get_estimator(self):

--- a/solvers/NO_DA_SOURCE_ONLY.py
+++ b/solvers/NO_DA_SOURCE_ONLY.py
@@ -17,25 +17,29 @@ with safe_import_context() as import_ctx:
 class Solver(DASolver):
 
     # Name to select the solver in the CLI and to display the results.
-    name = 'NO_DA_SOURCE_ONLY'
+    name = "NO_DA_SOURCE_ONLY"
 
     # List of parameters for the solver. The benchmark will consider
     # the cross product for each key in the dictionary.
     # All parameters 'p' defined here are available as 'self.p'.
-    param_grid = {
-        'classifier': [
-            SelectSource(LogisticRegression()
-                         .set_score_request(sample_weight=True)),
-            SelectSource(SVC(kernel='linear', probability=True)
-                         .set_score_request(sample_weight=True)),
-            SelectSource(XGBClassifier()
-                         .set_score_request(sample_weight=True)
-            )
-        ]
+    param_grid_dict = {
+        "simulated": {
+            "classifier": [
+                SelectSource(
+                    LogisticRegression().set_score_request(sample_weight=True)
+                ),
+                SelectSource(
+                    SVC(kernel="linear", probability=True).set_score_request(
+                        sample_weight=True
+                    )
+                ),
+                SelectSource(
+                    XGBClassifier().set_score_request(sample_weight=True)
+                ),
+            ]
+        }
     }
 
     def get_estimator(self):
         # The estimator passed should have a 'predict_proba' method.
-        return Pipeline([
-            ('classifier', None)
-        ])
+        return Pipeline([("classifier", None)])

--- a/solvers/NO_DA_TARGET_ONLY.py
+++ b/solvers/NO_DA_TARGET_ONLY.py
@@ -9,7 +9,6 @@ with safe_import_context() as import_ctx:
     from sklearn.linear_model import LogisticRegression
     from skada.base import SelectTarget
     from skada import make_da_pipeline
-    from sklearn.pipeline import Pipeline
     from xgboost import XGBClassifier
 
 
@@ -18,25 +17,31 @@ with safe_import_context() as import_ctx:
 class Solver(DASolver):
 
     # Name to select the solver in the CLI and to display the results.
-    name = 'NO_DA_TARGET_ONLY'
+    name = "NO_DA_TARGET_ONLY"
 
     # List of parameters for the solver. The benchmark will consider
     # the cross product for each key in the dictionary.
     # All parameters 'p' defined here are available as 'self.p'.
-    param_grid = {
-        'classifier': [
-            SelectTarget(LogisticRegression()
-                         .set_score_request(sample_weight=True)),
-            SelectTarget(SVC(kernel='linear', probability=True)
-                         .set_score_request(sample_weight=True)),
-            SelectTarget(XGBClassifier()
-                         .set_score_request(sample_weight=True)
-            )
-        ]
+    param_grid_dict = {
+        "simulated": {
+            "classifier": [
+                SelectTarget(
+                    LogisticRegression().set_score_request(sample_weight=True)
+                ),
+                SelectTarget(
+                    SVC(kernel="linear", probability=True).set_score_request(
+                        sample_weight=True
+                    )
+                ),
+                SelectTarget(
+                    XGBClassifier().set_score_request(sample_weight=True)
+                ),
+            ]
+        }
     }
 
     def get_estimator(self):
         # The estimator passed should have a 'predict_proba' method.
         return make_da_pipeline(
-            ('classifier', SelectTarget(LogisticRegression())),
+            ("classifier", SelectTarget(LogisticRegression())),
         )

--- a/solvers/OT_MAPPING.py
+++ b/solvers/OT_MAPPING.py
@@ -19,10 +19,11 @@ class Solver(DASolver):
     # List of parameters for the solver. The benchmark will consider
     # the cross product for each key in the dictionary.
     # All parameters 'p' defined here are available as 'self.p'.
-    param_grid = {
-        'otmappingadapter__metric': ['sqeuclidean'],
-        'otmappingadapter__norm': [None, 'median', 'max'],
-        'otmappingadapter__max_iter': [100_000]
+    param_grid_dict = {'simulated': {
+            'otmappingadapter__metric': ['sqeuclidean'],
+            'otmappingadapter__norm': [None, 'median', 'max'],
+            'otmappingadapter__max_iter': [100_000]
+        }
     }
 
     def get_estimator(self):

--- a/solvers/PCA.py
+++ b/solvers/PCA.py
@@ -21,8 +21,9 @@ class Solver(DASolver):
     # List of parameters for the solver. The benchmark will consider
     # the cross product for each key in the dictionary.
     # All parameters 'p' defined here are available as 'self.p'.
-    param_grid = {
-        'pca__n_components': [2]
+    param_grid_dict = {'simulated': {
+            'pca__n_components': [1]
+        }
     }
     # Raise an error if n_components > min(n_samples, n_features)
     # and doesnt save the result in the benchmark results
@@ -31,8 +32,9 @@ class Solver(DASolver):
         # The estimator passed should have a 'predict_proba' method.
         return make_da_pipeline(
             SelectSource(PCA()),
-            SelectSource(XGBClassifier()
-                         .set_fit_request(sample_weight=True)
-                         .set_score_request(sample_weight=True)
+            SelectSource(
+                XGBClassifier()
+                .set_fit_request(sample_weight=True)
+                .set_score_request(sample_weight=True)
             ),
         )

--- a/solvers/SUBSPACE_ALIGNMENT.py
+++ b/solvers/SUBSPACE_ALIGNMENT.py
@@ -19,8 +19,9 @@ class Solver(DASolver):
     # List of parameters for the solver. The benchmark will consider
     # the cross product for each key in the dictionary.
     # All parameters 'p' defined here are available as 'self.p'.
-    param_grid = {
-        'subspacealignmentadapter__n_components': [2],
+    param_grid_dict = {'simulated': {
+            'subspacealignmentadapter__n_components': [1],
+        }
     }
 
     def get_estimator(self):

--- a/solvers/TRANSFER_COMPONENT_ANALYSIS.py
+++ b/solvers/TRANSFER_COMPONENT_ANALYSIS.py
@@ -19,10 +19,11 @@ class Solver(DASolver):
     # List of parameters for the solver. The benchmark will consider
     # the cross product for each key in the dictionary.
     # All parameters 'p' defined here are available as 'self.p'.
-    param_grid = {
-        'transfercomponentanalysisadapter__kernel': ['rbf'],
-        'transfercomponentanalysisadapter__n_components': [2, 3],
-        'transfercomponentanalysisadapter__mu': [0.01, 0.1]
+    param_grid_dict = {'simulated': {
+            'transfercomponentanalysisadapter__kernel': ['rbf'],
+            'transfercomponentanalysisadapter__n_components': [1],
+            'transfercomponentanalysisadapter__mu': [0.1, 0.5, 1, 5]
+        }
     }
 
     def get_estimator(self):

--- a/solvers/TarS.py
+++ b/solvers/TarS.py
@@ -19,11 +19,12 @@ class Solver(DASolver):
     # List of parameters for the solver. The benchmark will consider
     # the cross product for each key in the dictionary.
     # All parameters 'p' defined here are available as 'self.p'.
-    param_grid = {
-        'mmdtarsreweightadapter__gamma': [0.1, 1, 10],
-        'mmdtarsreweightadapter__reg': [1e-10, 1e-8, 1e-6],
-        'mmdtarsreweightadapter__tol': [1e-6, 1e-4],
-        'mmdtarsreweightadapter__max_iter': [1000],
+    param_grid_dict = {'simulated': {
+            'mmdtarsreweightadapter__gamma': [0.1, 1, 10],
+            'mmdtarsreweightadapter__reg': [1e-10, 1e-8, 1e-6],
+            'mmdtarsreweightadapter__tol': [1e-6, 1e-4],
+            'mmdtarsreweightadapter__max_iter': [1000],
+        }
     }
 
     def get_estimator(self):

--- a/solvers/class_regularizer_ot_mapping.py
+++ b/solvers/class_regularizer_ot_mapping.py
@@ -19,14 +19,15 @@ class Solver(DASolver):
     # List of parameters for the solver. The benchmark will consider
     # the cross product for each key in the dictionary.
     # All parameters 'p' defined here are available as 'self.p'.
-    param_grid = {
-        'classregularizerotmappingadapter__reg_e': [1.0, 0.1],
-        'classregularizerotmappingadapter__reg_cl': [0.1, 0.01],
-        'classregularizerotmappingadapter__norm': ["lpl1", "l1l2"],
-        'classregularizerotmappingadapter__metric': ["sqeuclidean"],
-        'classregularizerotmappingadapter__max_iter': [10, 100],
-        'classregularizerotmappingadapter__max_inner_iter': [100],
-        'classregularizerotmappingadapter__tol': [10e-9, 10e-10],
+    param_grid_dict = {'simulated': {
+            'classregularizerotmappingadapter__reg_e': [1.0, 0.1],
+            'classregularizerotmappingadapter__reg_cl': [0.1, 0.01],
+            'classregularizerotmappingadapter__norm': ["lpl1", "l1l2"],
+            'classregularizerotmappingadapter__metric': ["sqeuclidean"],
+            'classregularizerotmappingadapter__max_iter': [10, 100],
+            'classregularizerotmappingadapter__max_inner_iter': [100],
+            'classregularizerotmappingadapter__tol': [10e-9, 10e-10],
+        }
     }
 
     def get_estimator(self):

--- a/solvers/discriminator_reweight.py
+++ b/solvers/discriminator_reweight.py
@@ -19,7 +19,7 @@ class Solver(DASolver):
     # List of parameters for the solver. The benchmark will consider
     # the cross product for each key in the dictionary.
     # All parameters 'p' defined here are available as 'self.p'.
-    param_grid = {}
+    param_grid_dict = {'simulated': {}}
 
     def get_estimator(self):
         # The estimator passed should have a 'predict_proba' method.

--- a/solvers/entropic_ot_mapping.py
+++ b/solvers/entropic_ot_mapping.py
@@ -19,12 +19,13 @@ class Solver(DASolver):
     # List of parameters for the solver. The benchmark will consider
     # the cross product for each key in the dictionary.
     # All parameters 'p' defined here are available as 'self.p'.
-    param_grid = {
-        'entropicotmappingadapter__reg_e': [1, 10],
-        'entropicotmappingadapter__metric': ['sqeuclidean'],
-        'entropicotmappingadapter__norm': [None, 'median', 'max'],
-        'entropicotmappingadapter__max_iter': [1000],
-        'entropicotmappingadapter__tol': [10e-9]
+    param_grid_dict = {'simulated': {
+            'entropicotmappingadapter__reg_e': [1, 10],
+            'entropicotmappingadapter__metric': ['sqeuclidean'],
+            'entropicotmappingadapter__norm': [None, 'median', 'max'],
+            'entropicotmappingadapter__max_iter': [1000],
+            'entropicotmappingadapter__tol': [10e-9]
+        }
     }
 
     def get_estimator(self):

--- a/solvers/gaussian_reweight.py
+++ b/solvers/gaussian_reweight.py
@@ -19,8 +19,9 @@ class Solver(DASolver):
     # List of parameters for the solver. The benchmark will consider
     # the cross product for each key in the dictionary.
     # All parameters 'p' defined here are available as 'self.p'.
-    param_grid = {
-        'gaussianreweightadapter__reg': ["auto", 1e-5, 0.5],
+    param_grid_dict = {'simulated': {
+            'gaussianreweightadapter__reg': ["auto", 1e-5, 0.5],
+        }
     }
 
     def get_estimator(self):

--- a/solvers/linear_ot_mapping.py
+++ b/solvers/linear_ot_mapping.py
@@ -19,9 +19,10 @@ class Solver(DASolver):
     # List of parameters for the solver. The benchmark will consider
     # the cross product for each key in the dictionary.
     # All parameters 'p' defined here are available as 'self.p'.
-    param_grid = {
-        'linearotmappingadapter__reg': [1e-08, 1e-06],
-        'linearotmappingadapter__bias': [True, False]
+    param_grid_dict = {'simulated': {
+            'linearotmappingadapter__reg': [1e-08, 1e-06],
+            'linearotmappingadapter__bias': [True, False]
+        }
     }
 
     def get_estimator(self):


### PR DESCRIPTION
I made this PR first to change the grid for TCA, because you were using `n_components` equal to 2 or 3, but for the simulated dataset you want `n_components=1`. But since it is specific to the simulated dataset, I make a param_grid specific for each dataset. Now, the dataset returns also the name of the dataset, and the grid is a dict where the keys are the name of the dataset.