### PR TITLE
Try catch when refitting estimators + add KLIEP auto/scale gammas

### DIFF
--- a/benchmark_utils/base_solver.py
+++ b/benchmark_utils/base_solver.py
@@ -94,18 +94,21 @@ class DASolver(BaseSolver):
             best_params = self.clf.cv_results_['params'][best_index]
             refit_estimator = clone(self.base_estimator)
             refit_estimator.set_params(**best_params)
-
-            if self.name == 'NO_DA_TARGET_ONLY':
-                refit_estimator.fit(
-                    self.X,
-                    self.unmasked_y_train,
-                    sample_domain=self.sample_domain
-                )
-            else:
-                refit_estimator.fit(
-                    self.X, self.y, sample_domain=self.sample_domain
-                )
-            self.dict_estimators_[criterion] = refit_estimator
+            
+            try:
+                if self.name == 'NO_DA_TARGET_ONLY':
+                    refit_estimator.fit(
+                        self.X,
+                        self.unmasked_y_train,
+                        sample_domain=self.sample_domain
+                    )
+                else:
+                    refit_estimator.fit(
+                        self.X, self.y, sample_domain=self.sample_domain
+                    )
+                self.dict_estimators_[criterion] = refit_estimator
+            except Exception as e:
+                print(f"Error while fitting estimator: {e}")
 
     def get_result(self):
         return dict(

--- a/solvers/KLIEP.py
+++ b/solvers/KLIEP.py
@@ -20,7 +20,7 @@ class Solver(DASolver):
     # the cross product for each key in the dictionary.
     # All parameters 'p' defined here are available as 'self.p'.
     param_grid = {
-        'kliepreweightadapter__gamma': [0.1, 1, 10],
+        'kliepreweightadapter__gamma': [0.1, 1, 10, 'auto', 'scale'],
         'kliepreweightadapter__cv': [3, 5],
         'kliepreweightadapter__n_centers': [5, 10, 20],
         'kliepreweightadapter__tol': [1e-3, 1e-4],


### PR DESCRIPTION
- Try catch when refitting estimators
- Add KLIEP auto/scale gammas

--> Why? Because with the old gammas in the param grid we would get always Nan alphas in KLIEP. Thus adding the 'auto' and 'scale' gammas, we can have more coherent dataset suited gammas