### PR TITLE
Fix max slurm time on margaret

### DIFF
--- a/config/example_margaret_slurm.yaml
+++ b/config/example_margaret_slurm.yaml
@@ -3,7 +3,7 @@
 # - mail-user: the email address to receive notifications
 # - source activate env_name: the name of the conda environment to activate
 
-slurm_time: 09:59:00        # max runtime 10 hours
+slurm_time: 7-00:00:00        # max runtime 7 days
 slurm_additional_parameters:
   job-name: skada-bench # Job name
   output: slurm_output.txt # Output file


### PR DESCRIPTION
I had a weird bug that prevented me to run jobs for more than 10h. Now, I can run for 7 days.