### PR TITLE
Add script to compute computational time from benchopt output

### DIFF
--- a/visualize/get_computational_time.py
+++ b/visualize/get_computational_time.py
@@ -95,8 +95,9 @@ def process_files_in_directory(directory):
         plt.tight_layout()
         plt.legend(loc='upper left')
         plt.ylabel("Mean computational time (in sec)")
+        plt.xlabel("")
         
-        fig.savefig('estimator_VS_time.png', dpi=100)
+        fig.savefig('estimator_VS_time_barplot.png', dpi=100)
 
 
 


### PR DESCRIPTION
With the latest experiment outputs, ie from 04/06 - 04:00pm:
```
Computational time:
Hours: 237, Minutes: 0, Seconds: 13.99
```