### PR TITLE
[MRG] Fix generate base estim config file script for Mac users

### DIFF
--- a/benchmark_utils/generate_config/generate_base_estim_config.py
+++ b/benchmark_utils/generate_config/generate_base_estim_config.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
         if spec is None:
             # Safety check in case spec creation fails
             continue
-            
+
         foo = importlib.util.module_from_spec(spec)
         sys.modules[name] = foo
         spec.loader.exec_module(foo)

--- a/benchmark_utils/generate_config/generate_base_estim_config.py
+++ b/benchmark_utils/generate_config/generate_base_estim_config.py
@@ -30,13 +30,19 @@ if __name__ == "__main__":
     )[2]
 
     for name in filenames_dataset:
-        if name.startswith('deep'):
-            # We dont want to include the deep datasets
+        if not name.endswith('.py') or name.startswith('deep'):
+            # To skip non-Python files like .DS_Store
+            # + to skip deep datasets
             continue
 
         spec = importlib.util.spec_from_file_location(
             name, os.path.join(PATH_skada_bench, "datasets", name)
         )
+
+        if spec is None:
+            # Safety check in case spec creation fails
+            continue
+            
         foo = importlib.util.module_from_spec(spec)
         sys.modules[name] = foo
         spec.loader.exec_module(foo)


### PR DESCRIPTION
Improvements to dataset file handling:

* Modified the file filtering logic to skip non-Python files and deep datasets by checking file extensions and prefixes. This ensures that only relevant Python files are processed.

Safety enhancements:

* Added a safety check to ensure that the `spec` creation is successful before proceeding with module import. This prevents potential errors if the `spec` creation fails.